### PR TITLE
Move over browser.rb from bundle support.

### DIFF
--- a/Support/lib/blogging.rb
+++ b/Support/lib/blogging.rb
@@ -488,7 +488,7 @@ TEXT
       current_password = self.password
       self.post = client.getPost(self.post_id, self.username, current_password)
       if self.publish && link = self.post['permaLink']
-        require "#{ENV['TM_SUPPORT_PATH']}/lib/browser"
+        require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/browser"
         Browser.load_url(link)
       end
       @mw_success = true

--- a/Support/lib/browser.rb
+++ b/Support/lib/browser.rb
@@ -1,0 +1,98 @@
+require "#{ENV['TM_SUPPORT_PATH']}/lib/osx/plist"
+
+require 'uri'
+
+module Browser
+  class << self
+    def load_url(url)
+      url = URI.parse(url.to_s)
+      return if url.scheme.nil?
+      browsers = [
+        { :name => "Camino",  :id => "org.mozilla.camino" },
+        { :name => "OmniWeb", :id => "com.omnigroup.omniweb5" },
+        { :name => "Safari",  :id => "com.apple.safari" },
+        { :name => "Safari",  :id => "org.webkit.nightly.webkit" },
+      ]
+
+      fav = favorite.to_s.downcase
+      browsers.each do |browser|
+        if fav == browser[:id] && (%x{ps -xc|grep -qs #{browser[:name]}}; $?.exitstatus == 0) then
+          return if self.send(browser[:id].tr('.', '_') + '_did_load?', url)
+        end
+      end
+
+      %x{open '#{url}'}
+    end
+
+    def favorite
+      rec = nil
+      open(File.expand_path("~/Library/Preferences/com.apple.LaunchServices.plist")) do |io|
+        rec = OSX::PropertyList.load(io)["LSHandlers"].find { |info| info["LSHandlerURLScheme"] == "http" }
+      end
+    rescue
+    ensure
+      return rec ? rec["LSHandlerRoleAll"] : nil
+    end
+
+    def org_mozilla_camino_did_load?(url)
+      %x{osascript <<'APPLESCRIPT'
+      	tell app "Camino"
+      		set theWindows to windows where visible is true
+      		if theWindows is not { }
+      			set the_url to URL of (first item of theWindows)
+      			if the_url is "#{url}" then
+      				activate
+      				tell app "System Events" to keystroke "r" using {command down}
+      				return true
+      			end if
+      		end if
+      	end tell
+APPLESCRIPT} =~ /true/
+    end
+
+    def com_omnigroup_omniweb5_did_load?(url)
+      %x{osascript <<'APPLESCRIPT'
+      	tell app "OmniWeb"
+        	if browsers is not { }
+        		set the_url to address of first browser
+        		if the_url is "#{url}" then
+        			activate
+        			tell app "System Events" to keystroke "r" using {command down}
+        			return true
+        		end if
+        	end if
+        end tell
+APPLESCRIPT} =~ /true/
+    end
+
+    def com_apple_safari_did_load?(url)
+      %x{osascript <<'APPLESCRIPT'
+      	tell app "Safari"
+      		if documents is not { }
+      			set the_url to URL of first document
+      			if the_url is "#{url}" then
+      				activate
+      				do JavaScript "window.location.reload();" in first document
+      				return true
+      			end if
+      		end if
+      	end tell
+APPLESCRIPT} =~ /true/
+    end
+
+    def org_webkit_nightly_webkit_did_load?(url)
+      %x{osascript <<'APPLESCRIPT'
+      	tell app "WebKit"
+      		if documents is not { }
+      			set the_url to URL of first document
+      			if the_url is "#{url}" then
+      				activate
+      				do JavaScript "window.location.reload();" in first document
+      				return true
+      			end if
+      		end if
+      	end tell
+APPLESCRIPT} =~ /true/
+    end
+  end
+end


### PR DESCRIPTION
This is the only bundle where that functionality it used. As it looks kinda outdated (I suspect it falls back to just executing `open <url>` in the vast majority of the cases anyway) I don’t think it makes sense to have it in bundle support.
